### PR TITLE
Fix ranking system labelling

### DIFF
--- a/core/LCE/app/src/main/java/LCE/App.java
+++ b/core/LCE/app/src/main/java/LCE/App.java
@@ -124,6 +124,7 @@ public class App {
         appLogger.trace(ANSI_BLUE + "[status] > Initiating gitLoader" + ANSI_RESET);
 
         // retreive candidate source codes from each git repositories
+        gitLoader.setmaxCandidateNum(stringListofCommitFile.size());
         int counter = 0;
         for (String[] line : stringListofCommitFile) {
             gitLoader.setCounter(counter);

--- a/core/LCE/app/src/main/java/LCE/App.java
+++ b/core/LCE/app/src/main/java/LCE/App.java
@@ -126,7 +126,7 @@ public class App {
         // retreive candidate source codes from each git repositories
         int counter = 0;
         for (String[] line : stringListofCommitFile) {
-            gitLoader.getCounter(counter);
+            gitLoader.setCounter(counter);
 
             String git_url = line[4];
             String cid_before = line[0];

--- a/core/LCE/app/src/main/java/LCE/GitLoader.java
+++ b/core/LCE/app/src/main/java/LCE/GitLoader.java
@@ -104,7 +104,7 @@ public class GitLoader {
      *
      * @param counter The counter value to set.
      */
-    public void getCounter(int counter) {
+    public void setCounter(int counter) {
         this.counter = counter;
     }
 

--- a/core/LCE/app/src/main/java/LCE/GitLoader.java
+++ b/core/LCE/app/src/main/java/LCE/GitLoader.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.FileUtils;
 import java.nio.file.Files;
 
 public class GitLoader {
+    private int maxCandidateNum = -1;
     private int counter = -1;
     private String url; // git url
     private String name; // git repo name
@@ -109,6 +110,15 @@ public class GitLoader {
     }
 
     /**
+     * Sets the maximum number of candidates to track
+     *
+     * @param maxCandidateNum The maxCandidateNum value to set.
+     */
+    public void setmaxCandidateNum(int maxCandidateNum) {
+        this.maxCandidateNum = maxCandidateNum;
+    }
+
+    /**
      * Extracts the repository name from a Git repository URL.
      *
      * @param url The Git repository URL.
@@ -187,16 +197,19 @@ public class GitLoader {
             Process p = pb.start();
             p.waitFor();
             gitLogger.trace(App.ANSI_GREEN + "[status] > git checkout success" + App.ANSI_RESET);
+
+            int paddingLength = String.valueOf(maxCandidateNum).length();
+            String paddedCounter = String.format("%0" + paddingLength + "d", counter);
             
             if (oldFile) {
                 if (copy(directory + "/" + filepathBefore,
-                        candidateDir + "/" + project + "_rank-" + counter + "_old.java"))
+                        candidateDir + "/" + project + "_rank-" + paddedCounter + "_old.java"))
                     return true;
                 else 
                     return false;
             } else {
                 if (copy(directory + "/" + filepathAfter,
-                        candidateDir + "/" + project + "_rank-" + counter + "_new.java"))
+                        candidateDir + "/" + project + "_rank-" + paddedCounter + "_new.java"))
                     return true;
                 else
                     return false;


### PR DESCRIPTION
#### 77cfd4629b6ae36f9b1092ceb6b611bf0eb7f65f
Found a setter method that was named `getCounter()`.

#### f09f0bd0b75536346e8571898ff70a9a4147eff4
The original ranking system labelling process started from `0` to `10` and beyond.
However, because SPI provided ConFix with the directory of the candidates ConFix used the candidates in the directory in alphabetical order. This was problem because ranks such as `100` can be used before(ranked higher) than rank `2`.
To solve this problem I added padding to the candidate filenames based on the maximum number of candidates.

Example where the number of candidates is 100:
```
Original:
- rank-0
- ...
- rank-100
- ...
- rank-2

Modified:
- rank-000
- ...
- rank-002
- ...
- rank-100
```